### PR TITLE
test: drop Node 10, add Node 16

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
I don't think it makes sense to be testing a fresh project on Node 10 anymore. Maybe we should even drop Node 12, since I've set the build target to Node 14 in the other PR?