### PR TITLE
Update package.json - set engine to node 22 minimum

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/ioBroker/adapter-dev#readme",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
node 20 is deprecated

Would be nice to get this released to get rid of CI warnings